### PR TITLE
Refactor get_rules out of is_allowed, and fixed PreparedRequests issue

### DIFF
--- a/src/requests_robotstxt.py
+++ b/src/requests_robotstxt.py
@@ -115,7 +115,7 @@ class RobotsAwareSession(requests.Session):
         return rerp
          
     def send(self, request, **kwargs):
-        if getattr(request, 'prepare', None):
+        if not isinstance(request, requests.PreparedRequest):
             raise ValueError('You can only send PreparedRequests.')
         if not self.is_allowed(request):
             raise RobotsTxtDisallowed(request.url)

--- a/src/requests_robotstxt.py
+++ b/src/requests_robotstxt.py
@@ -78,14 +78,18 @@ class RobotsAwareSession(requests.Session):
 
     def is_allowed(self, request, timeout=None, proxies=None,
                    verify=None, cert=None):
-        rerp = self.get_rules(request.url)
+        rerp = self.get_rules(
+            request.url, timeout=timeout, proxies=proxies,
+            verify=verify, cert=cert,
+        )
 
         if rerp is None:   # 404 - everybody welcome
             return True
         user_agent = request.headers.get('User-Agent', '')
         return rerp.is_allowed(user_agent, request.url)
     
-    def get_rules(self, request_url):
+    def get_rules(self, request_url, timeout=None, proxies=None,
+                  verify=None, cert=None):
         url = urlsplit(request_url)
         robots_url = '{0}://{1}/robots.txt'.format(
             url.scheme,

--- a/test/test_robotstxt.py
+++ b/test/test_robotstxt.py
@@ -45,7 +45,7 @@ class TestRobotsAwareSession(unittest.TestCase):
         self.assertEqual(s.get('https://pypi.python.org/').status_code, 200)
         self.assertIn('https://pypi.python.org/robots.txt', s.registry)
         with self.assertRaises(RobotsTxtDisallowed):
-            s.get('https://pypi.python.org/packages/')
+            s.get('https://github.com/')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In many applications, other rules in the robots.txt may be relevant to the application code; this makes it simpler for application code to retrieve these extra rules.

I've also incorporated the changes from Pull Request #1, and fixed the unit tests.